### PR TITLE
Error handling fixes

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -86,8 +86,10 @@ node.prototype.log = function(level, event, message) {
 
   if (level === 'debug' && this.debug) {
     console.log('bolt'.magenta + ' debug '.blue + message);
+  } else if (level === 'error') {
+    console.log('bolt'.magenta + ' error '.red + message);
   } else {
-    console.log('bolt'.magenta + ' info '.blue + '' + message);
+    console.log('bolt'.magenta + ' info '.blue + message);
   }
 }
 
@@ -133,7 +135,7 @@ node.prototype.receive = function(that, channel, message){
   try {
     message = JSON.parse(message);
   } catch (e) {
-    console.log([message, e]);
+    this.log('error', 'message', JSON.stringify({message: message, error: e}));
   }
 
   if (message) {

--- a/lib/node.js
+++ b/lib/node.js
@@ -129,10 +129,6 @@ node.prototype.error = function(source, e){
   }
 }
 
-node.prototype.subscribed = function(){
-  console.log(arguments);
-}
-
 node.prototype.receive = function(that, channel, message){
   try {
     message = JSON.parse(message);

--- a/lib/node.js
+++ b/lib/node.js
@@ -78,24 +78,16 @@ node.prototype.start = function(){
 node.prototype.log = function(level, event, message) {
   if (this.silent) return;
 
-  if (!message && event) {
+  if (!message) {
     message = event;
+  } else {
+    message = event.grey + ' ' + message;
   }
 
-  if (!event && level) {
-    message = level;
-  }
-
-  message = event ? event.grey + ' ' + message : message;
-
-  switch (level) {
-    case 'debug':
-      if (this.debug) console.log('bolt'.magenta + ' debug '.blue + message);
-      break;
-    case 'info':
-    default:
-      console.log('bolt'.magenta + ' info '.blue + '' + message);
-      break;
+  if (level === 'debug' && this.debug) {
+    console.log('bolt'.magenta + ' debug '.blue + message);
+  } else {
+    console.log('bolt'.magenta + ' info '.blue + '' + message);
   }
 }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -101,7 +101,7 @@ node.prototype.log = function(level, event, message) {
 
 node.prototype.on = function(hook, callback){
   if (hook == 'error') {
-    errorHandler = callback;
+    this.errorHandler = callback;
   }
   return this.ee.on(hook, callback);
 }


### PR DESCRIPTION
Of note:
- set errorHandler correctly
- require a `level` in `Node.log()` (no-level logging isn't used anywhere)
- log error-level messages with a red "error"
